### PR TITLE
Redacted titles

### DIFF
--- a/github/blind.css
+++ b/github/blind.css
@@ -1,3 +1,6 @@
+body.br-blinded .br-label::after {
+  content: attr(redacted-label) !important;
+}
 
 li.js-issue-row.br-blind span.opened-by::after,
 span.br-redacted::after {

--- a/github/blind.css
+++ b/github/blind.css
@@ -2,6 +2,10 @@ body.br-blinded .br-label::after {
   content: attr(redacted-label) !important;
 }
 
+body:not(.br-blinded) span.br-title {
+  display: none !important;
+}
+
 li.js-issue-row.br-blind span.opened-by::after,
 span.br-redacted::after {
   content: "[redacted]";

--- a/github/common.js
+++ b/github/common.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const REDACTED = "[redacted]"
+
 function parsePR(url) {
   const re = /^(https:\/\/github.com)?\/([\w-]+\/[\w-]+\/pull\/\d+)/;
   const match = url.match(re);
@@ -94,37 +96,59 @@ async function addFlag(textarea) {
 
 observer.on("#submit-review #pull_request_review_body", addFlag);
 
+function getPRAuthor() {
+  const author = document.querySelector("a.author.pull-header-username");
+  return author && author.textContent.trim();
+}
+
 function augment(a) {
   if (a.classList.contains("br-author")) {
     return;
   }
-  const author = document.querySelector("a.author.pull-header-username");
+  const author = getPRAuthor();
   const who = a.getAttribute("href") || a.getAttribute("alt") || a.textContent;
 
-  if (author && who.endsWith(author.textContent.trim())) {
+  if (author && who.endsWith(author)) {
     const redacted = document.createElement("span");
-    a.parentNode.insertBefore(redacted, a);
-    redacted.className = "br-redacted";
-
+    redacted.classList.add("br-redacted");
     a.classList.add("br-author");
+
     if (a.tagName === "IMG" || a.querySelector("img")) {
       redacted.className = "br-avatar";
     }
+
+    a.parentNode.insertBefore(redacted, a);
   }
 }
 
 function augmentTooltip(a) {
-  const authorElement = document.querySelector("a.author.pull-header-username");
+  const author = getPRAuthor();
   const label = a.getAttribute("aria-label");
 
-  if (!(authorElement && label)) {
+  if (!(author && label)) {
     return;
   }
 
-  const author = authorElement.textContent.trim();
   if (label.includes(author)) {
-    a.setAttribute("redacted-label", label.replace(author, "[redacted]"));
+    a.setAttribute("redacted-label", label.replace(author, REDACTED));
     a.classList.add("br-label");
+  }
+}
+
+function augmentTitle(a) {
+  const author = getPRAuthor();
+  const who = a.title;
+
+  if (!(author && who)) {
+    return;
+  }
+
+  if (who.includes(author)) {
+    const redacted = a.cloneNode(true);
+    redacted.title = redacted.title.replace(author, REDACTED);
+    redacted.classList.add("br-title");
+    a.classList.add("br-author");
+    a.parentNode.insertBefore(redacted, a);
   }
 }
 
@@ -157,6 +181,7 @@ observer.on("div.flash > div > a.text-emphasized", augment);
 observer.on("div.gh-header-meta span.head-ref > span.user", augment);
 
 observer.on(".AvatarStack-body.tooltipped", augmentTooltip);
+observer.on("div.gh-header-meta span.head-ref", augmentTitle);
 
 async function toggle(e) {
   if (e.target.classList.contains("br-toggle")) {

--- a/github/common.js
+++ b/github/common.js
@@ -115,15 +115,15 @@ function augment(a) {
 
 function augmentTooltip(a) {
   const authorElement = document.querySelector("a.author.pull-header-username");
-  const who = a.getAttribute("aria-label");
+  const label = a.getAttribute("aria-label");
 
-  if (!(authorElement && who)) {
+  if (!(authorElement && label)) {
     return;
   }
 
   const author = authorElement.textContent.trim();
-  if (who.includes(author)) {
-    a.setAttribute("redacted-label", who.replace(author, "[redacted]"));
+  if (label.includes(author)) {
+    a.setAttribute("redacted-label", label.replace(author, "[redacted]"));
     a.classList.add("br-label");
   }
 }

--- a/github/common.js
+++ b/github/common.js
@@ -137,13 +137,13 @@ function augmentTooltip(a) {
 
 function augmentTitle(a) {
   const author = getPRAuthor();
-  const who = a.title;
+  const title = a.title;
 
-  if (!(author && who)) {
+  if (!(author && title)) {
     return;
   }
 
-  if (who.includes(author)) {
+  if (title.includes(author)) {
     const redacted = a.cloneNode(true);
     redacted.title = redacted.title.replace(author, REDACTED);
     redacted.classList.add("br-title");

--- a/github/common.js
+++ b/github/common.js
@@ -87,7 +87,7 @@ async function addFlag(textarea) {
   `);
   if (!await storage()) {
     // @ts-ignore
-    document.getElementById("br-flag").checked = true; 
+    document.getElementById("br-flag").checked = true;
   }
   button.addEventListener("click", submitReview);
 }
@@ -110,6 +110,21 @@ function augment(a) {
     if (a.tagName === "IMG" || a.querySelector("img")) {
       redacted.className = "br-avatar";
     }
+  }
+}
+
+function augmentTooltip(a) {
+  const authorElement = document.querySelector("a.author.pull-header-username");
+  const who = a.getAttribute("aria-label");
+
+  if (!(authorElement && who)) {
+    return;
+  }
+
+  const author = authorElement.textContent.trim();
+  if (who.includes(author)) {
+    a.setAttribute("redacted-label", who.replace(author, "[redacted]"));
+    a.classList.add("br-label");
   }
 }
 
@@ -140,6 +155,8 @@ observer.on("div.commit-meta .AvatarStack a.avatar", augment);
 
 observer.on("div.flash > div > a.text-emphasized", augment);
 observer.on("div.gh-header-meta span.head-ref > span.user", augment);
+
+observer.on(".AvatarStack-body.tooltipped", augmentTooltip);
 
 async function toggle(e) {
   if (e.target.classList.contains("br-toggle")) {


### PR DESCRIPTION
Merge after #32 

Fixes the title (pops up on mouse over) in the last part here:

fiji-flo wants to merge 2 commits into `zombie:master` from `[redacted]:redacted-tooltips`

Hovering over `[redacted]:redacted-tooltips` reveals `fiji-flo/blind-reviews:redacted-tooltips`